### PR TITLE
Exclude .node_modules.ember-try from releases

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,7 @@
 /dist
 /tests
 /tmp
+/.node_modules.ember-try
 **/.gitkeep
 .bowerrc
 .editorconfig


### PR DESCRIPTION
`.node_modules.ember-try` is included in releases right now and adds 100-200MBs to the download from npm.
Given that it is just test data it should be excluded from the release builds.