### PR TITLE
Update .npmignore to current blueprint default.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,17 +1,31 @@
-/bower_components
+# compiled output
+/dist/
+/tmp/
+
+# dependencies
+/bower_components/
+
+# misc
+/.bowerrc
+/.editorconfig
+/.ember-cli
+/.env*
+/.eslintignore
+/.eslintrc.js
+/.gitignore
+/.template-lintrc.js
+/.travis.yml
+/.watchmanconfig
+/bower.json
 /config/ember-try.js
-/dist
-/tests
-/tmp
-/.node_modules.ember-try
-**/.gitkeep
-.bowerrc
-.editorconfig
-.ember-cli
-.gitignore
-.eslintrc.js
-.watchmanconfig
-.travis.yml
-bower.json
-ember-cli-build.js
-testem.js
+/CONTRIBUTING.md
+/ember-cli-build.js
+/testem.js
+/tests/
+/yarn.lock
+.gitkeep
+
+# ember-try
+/.node_modules.ember-try/
+/bower.json.ember-try
+/package.json.ember-try


### PR DESCRIPTION
The current release is approximately 16MB (0.1.0 is 19MB) due to the
tarball including `.node_modules.ember-try/` (an old copy of
node_modules that was saved off during a `ember try:each` session).

This updates the `.npmignore` file to match the current (3.10) ember-cli
addon blueprint, which includes a fix for this.